### PR TITLE
docs: fix repository name in README clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ pip install streamlit rembg Pillow streamlit-image-comparison
 1. Clone the Repository:
 
 ```bash
-git clone https://github.com/your-username/background-remover-app.git
-cd background-remover-app
+git clone https://github.com/your-username/background-remover-ui.git
+cd background-remover-ui
 ```
 
 2. Create a virtual environment and activate it


### PR DESCRIPTION
## Summary
- fix README clone instructions to use `background-remover-ui`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895a1df61f88326a72f1eb016d358e9